### PR TITLE
Bump Storm version to 1.10.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,0 +1,48 @@
+name: Build Homebrew
+# Builds and tests Storm's homebrew installation
+
+on:
+  # needed to trigger the workflow manually
+  workflow_dispatch:
+  pull_request:
+  push:
+
+env:
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
+
+jobs:
+  # Build Homebrew formula
+  build:
+    name: Build Tests (${{ matrix.config.name }}, ${{ matrix.config.buildType }})
+    strategy:
+      matrix:
+        config:
+          - {name: "XCode 14.3, Intel",
+             distro: "macos-13",
+             xcode: "14.3",
+             buildType: "Release"
+            }
+          - {name: "XCode 15.4, ARM",
+             distro: "macos-14",
+             xcode: "15.4",
+             buildType: "Release"
+            }
+          - {name: "XCode 16.3, ARM",
+             distro: "macos-15",
+             xcode: "16.3",
+             buildType: "Release"
+            }
+    runs-on: ${{ matrix.config.distro }}
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.config.xcode }}
+      - name: Git clone
+        uses: actions/checkout@v4
+      - name: Build Storm from Homebrew formula
+        run: |
+          brew update
+          brew install -v --build-from-source ./Formula/stormchecker.rb
+      - name: Run Storm
+        run: storm --version | grep 'with flags .* -O3'

--- a/Formula/stormchecker.rb
+++ b/Formula/stormchecker.rb
@@ -1,9 +1,10 @@
 class Stormchecker < Formula
   desc "A modern probabilistic model checker"
   homepage "https://www.stormchecker.org"
-  url "https://github.com/moves-rwth/storm/archive/1.8.1.tar.gz"
-  version "1.8.1"
-  sha256 "13de6e7816f2b796db3557ac6b058e2ccab9cd129e243cfce93dd7cdd82f3ee1"
+  # version is extracted from url
+  url "https://github.com/moves-rwth/storm/archive/refs/tags/1.10.0.tar.gz"
+  sha256 "a9ce10666dfcb383a1ee04ac7e57d0a67a9dba681eee6c51358b5767ad6bab7d"
+  license "GPL-3.0-only"
   head "https://github.com/moves-rwth/storm.git", using: :git, branch: "master"
 
   # option "with-single-thread", "Build Storm using just one thread."
@@ -14,15 +15,11 @@ class Stormchecker < Formula
   depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "boost"
+  depends_on "cln"
+  depends_on "ginac"
   depends_on "glpk"
   depends_on "gmp"
   depends_on "hwloc"
-  on_intel do
-    depends_on "moves-rwth/misc/carl-storm" => ["with-cln", "with-ginac"]
-  end
-  on_arm do
-    depends_on "moves-rwth/misc/carl-storm"
-  end
   depends_on "xerces-c"
   depends_on "z3"
   depends_on "spot" => :optional
@@ -30,7 +27,6 @@ class Stormchecker < Formula
 
   def install
     args = %w[
-      -DSTORM_DEVELOPER=OFF
       -DCMAKE_BUILD_TYPE=RELEASE
       -DSTORM_COMPILE_WITH_CCACHE=OFF
       -DSTORM_EXCLUDE_TESTS_FROM_ALL=ON

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Installing storm via homebrew
+# Installing Storm via homebrew
 
-This tap provides the formula to install storm via homebrew. All you need to do is
+This tap provides the formula to install Storm via homebrew. All you need to do is
 
 ```sh
 brew tap moves-rwth/storm
 brew install stormchecker
 ``` 
 
-For more options when installing storm, please invoke
+For more options when installing Storm, please invoke
 
 ```sh
 brew info stormchecker 
@@ -15,10 +15,10 @@ brew info stormchecker
 
 after tapping this repository.
 
-After the installation, you should be able to invoke storm by just typing
+After the installation, you should be able to invoke Storm by just typing
 
 ```sh
 storm
 ```
 
-For instructions on how to use storm, we refer to [storm's website](https://moves-rwth.github.io/storm/).
+For instructions on how to use Storm, we refer to [Storm's website](https://www.stormchecker.org).


### PR DESCRIPTION
Bumped Storm version to 1.10.0 and added CI to test Homebrew formula.

The stormchecker formula does not depend on carl-storm anymore, because the shipped version of carl-storm should be used. This also makes it compatible with the future CMake updates in Storm.
The [homebrew-misc](https://github.com/moves-rwth/homebrew-misc/) will not be needed anymore and could be archived.